### PR TITLE
docs: point agents to master context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Mento Docs Instructions
+
+For any protocol-level question that crosses beyond this docs repo, first read
+the private `mento-master-context` router when the checkout is available:
+
+```text
+../mento-master-context/.agents/mento-context/README.md
+```
+
+This applies before broad repo searches for contracts, deployments, addresses,
+ABIs, live on-chain state, stable supply, reserve data, monitoring/data
+semantics, the whitepaper, business model, or legal/risk framing. Load only the
+relevant master-context card(s), then return to this repo for docs content and
+site implementation details.
+
+Docs are useful for official narrative and user-facing explanations, not proof
+of current on-chain values. Verify current values through the source-specific
+repo, API, RPC, or dashboard path the master context points to. When answering,
+mention which master-context card you used or state that the checkout was
+unavailable.


### PR DESCRIPTION
## Summary
- Add a root AGENTS.md pointer to the private mento-master-context router.
- Keep this repo as source of truth for local implementation details while routing cross-protocol questions to the compact context index first.

## Validation
- git diff --check
- local autoreview helper: no deterministic findings
- commit/push hooks ran where configured

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime, API, or deployment impact.
> 
> **Overview**
> Introduces a new root **`AGENTS.md`** so coding agents working in this docs repo follow a consistent workflow for questions that go beyond local site content.
> 
> Agents are told to read **`../mento-master-context/.agents/mento-context/README.md`** first (when that checkout exists) for protocol-wide topics—contracts, deployments, on-chain state, reserves, whitepaper, legal framing, and similar—instead of starting with broad searches here. They should load only the relevant context cards, then come back to this repo for docs narrative and implementation details.
> 
> The file also clarifies that docs are for user-facing explanation, not authoritative live on-chain values, and that answers should cite which master-context card was used or note when the checkout was unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82a7464fa9aa6c417b9a3428a88714092ef36036. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->